### PR TITLE
Downgrade package validation baseline to 0.1.0-preview.8.1.1

### DIFF
--- a/src/Pure.RelationalSchema.Storage.PostgreSQL/Pure.RelationalSchema.Storage.PostgreSQL.csproj
+++ b/src/Pure.RelationalSchema.Storage.PostgreSQL/Pure.RelationalSchema.Storage.PostgreSQL.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.1.0-preview.8.1.2</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.1.0-preview.8.1.1</PackageValidationBaselineVersion>
     <IsAotCompatible>false</IsAotCompatible>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Tag `0.1.0-preview.8.1.2` failed to publish to NuGet.org (500 Internal Server Error) even though it was pushed to GitHub Packages and the baseline was already bumped. Reverting the baseline so it matches the last version actually published to NuGet.org, ahead of deleting and repushing the `0.1.0-preview.8.1.2` tag.