### PR TITLE
Update package validation baseline to 0.1.0-preview.8.1.2

### DIFF
--- a/src/Pure.RelationalSchema.Storage.PostgreSQL/Pure.RelationalSchema.Storage.PostgreSQL.csproj
+++ b/src/Pure.RelationalSchema.Storage.PostgreSQL/Pure.RelationalSchema.Storage.PostgreSQL.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.1.0-preview.8.1.1</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.1.0-preview.8.1.2</PackageValidationBaselineVersion>
     <IsAotCompatible>false</IsAotCompatible>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Tag `0.1.0-preview.8.1.2` was successfully republished to both GitHub Packages and NuGet.org after the earlier NuGet.org 500 error. Restoring the baseline to match.